### PR TITLE
結果テーブルUIの更新（画面サイズに合わせたカラム表示、結果詳細ダイアログ実装）

### DIFF
--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -5,38 +5,34 @@ import 'package:provider/provider.dart';
 
 import '../../model/result_model.dart';
 import '../../view_model/providers.dart';
+import '../parts/result_dialog.dart'as ResultDialog;
 
 class ResultsTable extends HookConsumerWidget{
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final List<ResultModel> _results = ref.watch(resultStateNotifierProvider);
     var _screenSize = MediaQuery.of(context).size;
+    List<String> _columnList = this.getResultColumns(_screenSize.width);
 
     return SingleChildScrollView(
       child: FittedBox(
-        child: (_screenSize.width <= 500) ? this.mapToDataTableForMobilePhone(_results) : this.mapToDataTable(_results)
+        child: DataTable(
+          showCheckboxColumn: false,
+          columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
+          rows: _results.map((ResultModel result) => DataRow(
+            cells: this.mapToDataCells(_screenSize.width, result)
+          )).toList()
+        )
       ));
   }
-
-  DataTable mapToDataTableForMobilePhone(List<ResultModel> _results){
-    const List<String> _columnList = [
+  List<String> getResultColumns(var width){
+    List<String> res = [
         "created at",
         "status",
         "repository url"
-    ];
-    return DataTable(
-      columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
-      rows: _results.map((ResultModel result) => DataRow(
-        cells: <DataCell>[
-                DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
-                DataCell(Text(result.status)),
-                DataCell(Text(result.repository_url))
-              ]
-      )).toList()
-    );
-  }
-  DataTable mapToDataTable(List<ResultModel> _results){
-    const List<String> _columnList = [
+      ];
+    if (width >= 500){
+      res = [
         "created at",
         "status",
         "level",
@@ -46,22 +42,30 @@ class ResultsTable extends HookConsumerWidget{
         "game time",
         "trial number",
         "mean score"
-    ];
-    return DataTable(
-      columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
-      rows: _results.map((ResultModel result) => DataRow(
-        cells: <DataCell>[
-                DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
-                DataCell(Text(result.status)),
-                DataCell(Text(result.level.toString())),
-                DataCell(Text(result.repository_url)),
-                DataCell(Text(result.branch)),
-                DataCell(Text(result.game_mode)),
-                DataCell(Text(result.game_time.toString())),
-                DataCell(Text(result.trial_number.toString())),
-                DataCell(Text(result.mean_score.toString()))
-              ]
-      )).toList()
-    );
+      ];
+    }
+    return res;
+    }
+
+  List<DataCell> mapToDataCells(var width, ResultModel result){
+    List<DataCell> cells = [
+        DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
+        DataCell(Text(result.status)),
+        DataCell(Text(result.repository_url))
+      ];
+    if (width >= 500){
+      cells = [
+        DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
+        DataCell(Text(result.status)),
+        DataCell(Text(result.level.toString())),
+        DataCell(Text(result.repository_url)),
+        DataCell(Text(result.branch)),
+        DataCell(Text(result.game_mode)),
+        DataCell(Text(result.game_time.toString())),
+        DataCell(Text(result.trial_number.toString())),
+        DataCell(Text(result.mean_score.toString()))
+      ];
+    }
+    return cells;
   }
 }

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -16,6 +16,7 @@ class ResultsTable extends HookConsumerWidget{
 
     return SingleChildScrollView(
       child: FittedBox(
+        fit: BoxFit.fitWidth,
         child: DataTable(
           showCheckboxColumn: false,
           columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -11,9 +11,11 @@ class ResultsTable extends HookConsumerWidget{
   Widget build(BuildContext context, WidgetRef ref) {
     final List<ResultModel> _results = ref.watch(resultStateNotifierProvider);
     final List<String> _columnList = getResultColumns();
+    var _screenSize = MediaQuery.of(context).size;
 
     return SingleChildScrollView(
-      child: DataTable(
+      child: FittedBox(
+        child: DataTable(
         columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
         rows: _results.map((ResultModel result) => DataRow(
           cells: <DataCell>[
@@ -24,6 +26,6 @@ class ResultsTable extends HookConsumerWidget{
             DataCell(Text(result.mean_score.toString()))
           ]
         )).toList()
-      ));
+      )));
   }
 }

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -20,7 +20,7 @@ class ResultsTable extends HookConsumerWidget{
 
   DataTable mapToDataTableForMobilePhone(List<ResultModel> _results){
     const List<String> _columnList = [
-        "createdAt",
+        "created at",
         "status",
         "repository url"
     ];
@@ -39,8 +39,12 @@ class ResultsTable extends HookConsumerWidget{
     const List<String> _columnList = [
         "created at",
         "status",
+        "level",
         "repository url",
         "branch",
+        "game mode",
+        "game time",
+        "trial number",
         "mean score"
     ];
     return DataTable(
@@ -49,8 +53,12 @@ class ResultsTable extends HookConsumerWidget{
         cells: <DataCell>[
                 DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
                 DataCell(Text(result.status)),
+                DataCell(Text(result.level.toString())),
                 DataCell(Text(result.repository_url)),
                 DataCell(Text(result.branch)),
+                DataCell(Text(result.game_mode)),
+                DataCell(Text(result.game_time.toString())),
+                DataCell(Text(result.trial_number.toString())),
                 DataCell(Text(result.mean_score.toString()))
               ]
       )).toList()

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -20,18 +20,19 @@ class ResultsTable extends HookConsumerWidget{
           showCheckboxColumn: false,
           columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
           rows: _results.map((ResultModel result) => DataRow(
+            onSelectChanged: (_) => ResultDialog.showResultDialog(context, result),
             cells: this.mapToDataCells(_screenSize.width, result)
           )).toList()
         )
       ));
   }
   List<String> getResultColumns(var width){
-    List<String> res = [
+    List<String> res = [ // for mobile size
         "created at",
         "status",
         "repository url"
       ];
-    if (width >= 500){
+    if (width >= 700){ // for desktop size
       res = [
         "created at",
         "status",
@@ -53,7 +54,7 @@ class ResultsTable extends HookConsumerWidget{
         DataCell(Text(result.status)),
         DataCell(Text(result.repository_url))
       ];
-    if (width >= 500){
+    if (width >= 700){ // for desktop size
       cells = [
         DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
         DataCell(Text(result.status)),

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -10,22 +10,50 @@ class ResultsTable extends HookConsumerWidget{
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final List<ResultModel> _results = ref.watch(resultStateNotifierProvider);
-    final List<String> _columnList = getResultColumns();
     var _screenSize = MediaQuery.of(context).size;
 
     return SingleChildScrollView(
       child: FittedBox(
-        child: DataTable(
-        columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
-        rows: _results.map((ResultModel result) => DataRow(
-          cells: <DataCell>[
-            DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString())),
-            DataCell(Text(result.status)),
-            DataCell(Text(result.repository_url)),
-            DataCell(Text(result.branch)),
-            DataCell(Text(result.mean_score.toString()))
-          ]
-        )).toList()
-      )));
+        child: (_screenSize.width <= 500) ? this.mapToDataTableForMobilePhone(_results) : this.mapToDataTable(_results)
+      ));
+  }
+
+  DataTable mapToDataTableForMobilePhone(List<ResultModel> _results){
+    const List<String> _columnList = [
+        "createdAt",
+        "status",
+        "repository url"
+    ];
+    return DataTable(
+      columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
+      rows: _results.map((ResultModel result) => DataRow(
+        cells: <DataCell>[
+                DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
+                DataCell(Text(result.status)),
+                DataCell(Text(result.repository_url))
+              ]
+      )).toList()
+    );
+  }
+  DataTable mapToDataTable(List<ResultModel> _results){
+    const List<String> _columnList = [
+        "created at",
+        "status",
+        "repository url",
+        "branch",
+        "mean score"
+    ];
+    return DataTable(
+      columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
+      rows: _results.map((ResultModel result) => DataRow(
+        cells: <DataCell>[
+                DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
+                DataCell(Text(result.status)),
+                DataCell(Text(result.repository_url)),
+                DataCell(Text(result.branch)),
+                DataCell(Text(result.mean_score.toString()))
+              ]
+      )).toList()
+    );
   }
 }

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -3,14 +3,14 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:provider/provider.dart';
 
-import '../../model/result_model.dart';
+import '../../model/result_model.dart' as ResultModel;
 import '../../view_model/providers.dart';
 import '../parts/result_dialog.dart'as ResultDialog;
 
 class ResultsTable extends HookConsumerWidget{
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final List<ResultModel> _results = ref.watch(resultStateNotifierProvider);
+    final List<ResultModel.ResultModel> _results = ref.watch(resultStateNotifierProvider);
     var _screenSize = MediaQuery.of(context).size;
     List<String> _columnList = this.getResultColumns(_screenSize.width);
 
@@ -20,7 +20,7 @@ class ResultsTable extends HookConsumerWidget{
         child: DataTable(
           showCheckboxColumn: false,
           columns: _columnList.map((String column) => DataColumn(label: Text(column))).toList(),
-          rows: _results.map((ResultModel result) => DataRow(
+          rows: _results.map((ResultModel.ResultModel result) => DataRow(
             onSelectChanged: (_) => ResultDialog.showResultDialog(context, result),
             cells: this.mapToDataCells(_screenSize.width, result)
           )).toList()
@@ -49,15 +49,15 @@ class ResultsTable extends HookConsumerWidget{
     return res;
     }
 
-  List<DataCell> mapToDataCells(var width, ResultModel result){
+  List<DataCell> mapToDataCells(var width, ResultModel.ResultModel result){
     List<DataCell> cells = [
-        DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
+        DataCell(Text(ResultModel.datetimeToString(result.created_at))),
         DataCell(Text(result.status)),
         DataCell(Text(result.repository_url))
       ];
     if (width >= 700){ // for desktop size
       cells = [
-        DataCell(Text(DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().substring(0, DateTime.fromMillisecondsSinceEpoch(result.created_at).toString().length-4))),
+        DataCell(Text(ResultModel.datetimeToString(result.created_at))),
         DataCell(Text(result.status)),
         DataCell(Text(result.level.toString())),
         DataCell(Text(result.repository_url)),

--- a/app/lib/components/pages/results_page.dart
+++ b/app/lib/components/pages/results_page.dart
@@ -8,7 +8,7 @@ class ResultsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       body: Container(
-        margin: EdgeInsets.symmetric(vertical: 20, horizontal: 40),
+        margin: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
         child: ResultsTable(),
       ),
     );

--- a/app/lib/components/parts/result_dialog.dart
+++ b/app/lib/components/parts/result_dialog.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../model/result_model.dart' as ResultModel;
+
+Future<void> showResultDialog(BuildContext context, ResultModel.ResultModel result) async {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        content: SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              Text("url: ${result.repository_url}"),
+              Text("status: ${result.status}"),
+              Text("branch: ${result.branch}"),
+              Text("created at: ${ResultModel.datetimeToString(result.created_at)}"),
+              Text("level: ${result.level.toString()}"),
+              Text("number of trial: ${result.trial_number.toString()}"),
+              Text("game mode: ${result.game_mode}"),
+              Text("predict_weight_path: ${result.predict_weight_path}"),
+              Text("mean_score: ${result.mean_score.toString()}"),
+              Text("max_score: ${result.max_score.toString()}"),
+              Text("max_score: ${result.min_score.toString()}"),
+              Text("stddev_score: ${result.stddev_score.toString()}"),
+              Text("error message: ${result.error_message}")
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            child: const Text('close'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/app/lib/model/result_model.dart
+++ b/app/lib/model/result_model.dart
@@ -47,3 +47,9 @@ class ResultModel{
         min_score = map['MinScore'],
         error_message = map['ErrorMessage'];
 }
+
+String datetimeToString(int datetime){
+    String _datetime = DateTime.fromMillisecondsSinceEpoch(datetime
+    ).toString();
+    return _datetime.substring(0, _datetime.length-4);
+}

--- a/app/lib/model/result_model.dart
+++ b/app/lib/model/result_model.dart
@@ -20,13 +20,3 @@ class ResultModel{
         created_at = map['CreatedAt']*1000,
         mean_score = map['MeanScore'];
 }
-
-List<String> getResultColumns(){
-    return [
-        "createdAt",
-        "status",
-        "repository_url",
-        "branch",
-        "mean_score"
-    ];
-}

--- a/app/lib/model/result_model.dart
+++ b/app/lib/model/result_model.dart
@@ -4,13 +4,31 @@ class ResultModel{
     final String branch;
     final int created_at; // seconds since epoch
     final num mean_score;
+    final int game_time;
+    final int level;
+    final String game_mode;
+    final String predict_weight_path;
+    final int trial_number;
+    final num stddev_score;
+    final int max_score;
+    final int min_score;
+    final String error_message;
 
     ResultModel(
         this.repository_url,
         this.status,
         this.branch,
         this.created_at,
-        this.mean_score
+        this.mean_score,
+        this.game_time,
+        this.level,
+        this.game_mode,
+        this.predict_weight_path,
+        this.trial_number,
+        this.stddev_score,
+        this.max_score,
+        this.min_score,
+        this.error_message,
     );
     
     ResultModel.fromJson(dynamic map)
@@ -18,5 +36,14 @@ class ResultModel{
         status = map['Status'],
         branch = map['Branch'],
         created_at = map['CreatedAt']*1000,
-        mean_score = map['MeanScore'];
+        mean_score = map['MeanScore'],
+        game_time = map['GameTime'],
+        level = map['Level'],
+        game_mode = map['GameMode'],
+        predict_weight_path = map['ValuePredictWeight'],
+        trial_number = map['TrialNum'],
+        stddev_score = map['StdDevScore'],
+        max_score = map['MaxScore'],
+        min_score = map['MinScore'],
+        error_message = map['ErrorMessage'];
 }

--- a/app/lib/repository/db_repository.dart
+++ b/app/lib/repository/db_repository.dart
@@ -25,14 +25,32 @@ class DBRepositoryImpl implements DBRepository {
         "Status": "W",
         "RepositoryURL": "https://github.com/seigot/tetris",
         "Branch": "master",
-        "MeanScore": 100
+        "MeanScore": 100,
+        "GameTime": 180,
+        "Level": 1,
+        "GameMode": "default",
+        "ValuePredictWeight": "",
+        "TrialNum": 1,
+        "StdDevScore": 1,
+        "MaxScore": 100,
+        "MinScore": 100,
+        "ErrorMessage": ""
       },
       {
         "CreatedAt": 120000100,
         "Status": "S",
         "RepositoryURL": "https://github.com/seigot/tetris",
         "Branch": "master",
-        "MeanScore": 1000
+        "MeanScore": 1000,
+        "GameTime": 180,
+        "Level": 1,
+        "GameMode": "default",
+        "ValuePredictWeight": "",
+        "TrialNum": 1,
+        "StdDevScore": 1,
+        "MaxScore": 100,
+        "MinScore": 100,
+        "ErrorMessage": ""
       },
     ];
     

--- a/app/lib/repository/db_repository.dart
+++ b/app/lib/repository/db_repository.dart
@@ -11,14 +11,30 @@ abstract class DBRepository {
 class DBRepositoryImpl implements DBRepository {
   @override
   Future<List<ResultModel>> getLatestResults() async {
-    String? _api = dotenv.env['EVALUATION_REQUEST_API'];
-    if (_api==null){
-      return [];
-    }
-    final uri = Uri.parse("${_api}/results");
-    http.Response result = await http.get(uri);
-    var _map = convert.jsonDecode(result.body);
-    List<dynamic> items = _map['Items'];
+    // String? _api = dotenv.env['EVALUATION_REQUEST_API'];
+    // if (_api==null){
+    //   return [];
+    // }
+    // final uri = Uri.parse("${_api}/results");
+    // http.Response result = await http.get(uri);
+    // var _map = convert.jsonDecode(result.body);
+    // List<dynamic> items = _map['Items'];
+    List<dynamic> items = [
+      {
+        "CreatedAt": 1000001,
+        "Status": "W",
+        "RepositoryURL": "https://github.com/seigot/tetris",
+        "Branch": "master",
+        "MeanScore": 100
+      },
+      {
+        "CreatedAt": 120000100,
+        "Status": "S",
+        "RepositoryURL": "https://github.com/seigot/tetris",
+        "Branch": "master",
+        "MeanScore": 1000
+      },
+    ];
     
     List<ResultModel> results = items.map(
         (var item) => ResultModel.fromJson(item)

--- a/app/lib/repository/db_repository.dart
+++ b/app/lib/repository/db_repository.dart
@@ -11,48 +11,14 @@ abstract class DBRepository {
 class DBRepositoryImpl implements DBRepository {
   @override
   Future<List<ResultModel>> getLatestResults() async {
-    // String? _api = dotenv.env['EVALUATION_REQUEST_API'];
-    // if (_api==null){
-    //   return [];
-    // }
-    // final uri = Uri.parse("${_api}/results");
-    // http.Response result = await http.get(uri);
-    // var _map = convert.jsonDecode(result.body);
-    // List<dynamic> items = _map['Items'];
-    List<dynamic> items = [
-      {
-        "CreatedAt": 1000001,
-        "Status": "W",
-        "RepositoryURL": "https://github.com/seigot/tetris",
-        "Branch": "master",
-        "MeanScore": 100,
-        "GameTime": 180,
-        "Level": 1,
-        "GameMode": "default",
-        "ValuePredictWeight": "",
-        "TrialNum": 1,
-        "StdDevScore": 1,
-        "MaxScore": 100,
-        "MinScore": 100,
-        "ErrorMessage": ""
-      },
-      {
-        "CreatedAt": 120000100,
-        "Status": "S",
-        "RepositoryURL": "https://github.com/seigot/tetris",
-        "Branch": "master",
-        "MeanScore": 1000,
-        "GameTime": 180,
-        "Level": 1,
-        "GameMode": "default",
-        "ValuePredictWeight": "",
-        "TrialNum": 1,
-        "StdDevScore": 1,
-        "MaxScore": 100,
-        "MinScore": 100,
-        "ErrorMessage": ""
-      },
-    ];
+    String? _api = dotenv.env['EVALUATION_REQUEST_API'];
+    if (_api==null){
+      return [];
+    }
+    final uri = Uri.parse("${_api}/results");
+    http.Response result = await http.get(uri);
+    var _map = convert.jsonDecode(result.body);
+    List<dynamic> items = _map['Items'];
     
     List<ResultModel> results = items.map(
         (var item) => ResultModel.fromJson(item)


### PR DESCRIPTION
画面サイズに応じて、DataTableのカラム数を変更
スマホサイズでは表示カラムは最低限のものだけにして画面からはみ出さないようにする
行をタップしたら詳細情報が見れるダイアログを表示